### PR TITLE
[feat] 로그인 서비스 로컬 실행 환경 및 도메인 엔티티 초기 구성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U login -d login"]
+      test: ["CMD-SHELL", "pg_isready -U root -d login"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: login-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: login
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: root
+      TZ: Asia/Seoul
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U login -d login"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  redis:
+    image: redis:7-alpine
+    container_name: login-redis
+    restart: unless-stopped
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres-data:
+  redis-data:

--- a/src/main/java/com/pj/login/common/converter/YesNoBooleanConverter.java
+++ b/src/main/java/com/pj/login/common/converter/YesNoBooleanConverter.java
@@ -1,0 +1,18 @@
+package com.pj.login.common.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class YesNoBooleanConverter implements AttributeConverter<Boolean, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Boolean attribute) {
+        return Boolean.TRUE.equals(attribute) ? "Y" : "N";
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(String dbData) {
+        return "Y".equalsIgnoreCase(dbData);
+    }
+}

--- a/src/main/java/com/pj/login/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/pj/login/common/entity/BaseTimeEntity.java
@@ -1,0 +1,32 @@
+package com.pj.login.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/pj/login/common/entity/CreatedAtEntity.java
+++ b/src/main/java/com/pj/login/common/entity/CreatedAtEntity.java
@@ -1,0 +1,21 @@
+package com.pj.login.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class CreatedAtEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/pj/login/domain/auth/entity/Identity.java
+++ b/src/main/java/com/pj/login/domain/auth/entity/Identity.java
@@ -1,0 +1,70 @@
+package com.pj.login.domain.auth.entity;
+
+import com.pj.login.common.converter.YesNoBooleanConverter;
+import com.pj.login.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "identity")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Identity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "provider_type", nullable = false, length = 20)
+    private String providerType;
+
+    @Column(name = "provider_user_id", length = 255)
+    private String providerUserId;
+
+    @Column(name = "login_id", length = 100)
+    private String loginId;
+
+    @Column(name = "principal_email", length = 255)
+    private String principalEmail;
+
+    @Convert(converter = YesNoBooleanConverter.class)
+    @Column(name = "linked_yn", nullable = false, length = 1)
+    private boolean linked;
+
+    @OneToMany(mappedBy = "identity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Password> passwords = new ArrayList<>();
+
+    @Builder
+    private Identity(
+            String providerType,
+            String providerUserId,
+            String loginId,
+            String principalEmail,
+            boolean linked
+    ) {
+        this.providerType = providerType;
+        this.providerUserId = providerUserId;
+        this.loginId = loginId;
+        this.principalEmail = principalEmail;
+        this.linked = linked;
+    }
+
+    void assignUser(User user) {
+        this.user = user;
+    }
+
+    public void addPassword(Password password) {
+        passwords.add(password);
+        password.assignIdentity(this);
+    }
+}

--- a/src/main/java/com/pj/login/domain/auth/entity/LoginHistory.java
+++ b/src/main/java/com/pj/login/domain/auth/entity/LoginHistory.java
@@ -1,0 +1,64 @@
+package com.pj.login.domain.auth.entity;
+
+import com.pj.login.common.entity.CreatedAtEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "login_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginHistory extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId; // 히스토리성 데이터로 userId만 저장함
+
+    @Column(name = "provider_type", nullable = false, length = 20)
+    private String providerType;
+
+    @Column(name = "login_id", length = 100)
+    private String loginId;
+
+    @Column(name = "attempt_result", nullable = false, length = 20)
+    private String attemptResult;
+
+    @Column(name = "fail_reason", length = 100)
+    private String failReason;
+
+    @Column(name = "client_ip", length = 45)
+    private String clientIp;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @Builder
+    private LoginHistory(
+            Long userId,
+            String providerType,
+            String loginId,
+            String attemptResult,
+            String failReason,
+            String clientIp,
+            String userAgent
+    ) {
+        this.userId = userId;
+        this.providerType = providerType;
+        this.loginId = loginId;
+        this.attemptResult = attemptResult;
+        this.failReason = failReason;
+        this.clientIp = clientIp;
+        this.userAgent = userAgent;
+    }
+}

--- a/src/main/java/com/pj/login/domain/auth/entity/Password.java
+++ b/src/main/java/com/pj/login/domain/auth/entity/Password.java
@@ -1,0 +1,67 @@
+package com.pj.login.domain.auth.entity;
+
+import com.pj.login.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "passwords")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "identity_id", nullable = false)
+    private Identity identity;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "password_algo", nullable = false, length = 50)
+    private String passwordAlgo;
+
+    @Column(name = "password_changed_at", nullable = false)
+    private LocalDateTime passwordChangedAt;
+
+    @Column(name = "fail_count", nullable = false)
+    private int failCount;
+
+    @Column(name = "locked_until")
+    private LocalDateTime lockedUntil;
+
+    @Builder
+    private Password(
+            String passwordHash,
+            String passwordAlgo,
+            LocalDateTime passwordChangedAt,
+            int failCount,
+            LocalDateTime lockedUntil
+    ) {
+        this.passwordHash = passwordHash;
+        this.passwordAlgo = passwordAlgo;
+        this.passwordChangedAt = passwordChangedAt;
+        this.failCount = failCount;
+        this.lockedUntil = lockedUntil;
+    }
+
+    void assignIdentity(Identity identity) {
+        this.identity = identity;
+    }
+}

--- a/src/main/java/com/pj/login/domain/auth/entity/User.java
+++ b/src/main/java/com/pj/login/domain/auth/entity/User.java
@@ -1,0 +1,89 @@
+package com.pj.login.domain.auth.entity;
+
+import com.pj.login.common.converter.YesNoBooleanConverter;
+import com.pj.login.common.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_uuid", nullable = false, unique = true, updatable = false, columnDefinition = "uuid")
+    private UUID userUuid;
+
+    @Column(name = "account_status", nullable = false, length = 20)
+    private String accountStatus;
+
+    @Column(length = 255)
+    private String email;
+
+    @Convert(converter = YesNoBooleanConverter.class)
+    @Column(name = "email_verified_yn", nullable = false, length = 1)
+    private boolean emailVerified;
+
+    @Column(name = "phone_number", length = 20)
+    private String phoneNumber;
+
+    @Convert(converter = YesNoBooleanConverter.class)
+    @Column(name = "phone_verified_yn", nullable = false, length = 1)
+    private boolean phoneVerified;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Identity> identities = new ArrayList<>();
+
+    @Builder
+    private User(
+            UUID userUuid,
+            String accountStatus,
+            String email,
+            boolean emailVerified,
+            String phoneNumber,
+            boolean phoneVerified,
+            LocalDateTime lastLoginAt
+    ) {
+        this.userUuid = userUuid;
+        this.accountStatus = accountStatus;
+        this.email = email;
+        this.emailVerified = emailVerified;
+        this.phoneNumber = phoneNumber;
+        this.phoneVerified = phoneVerified;
+        this.lastLoginAt = lastLoginAt;
+    }
+
+    void assignUserUuidIfAbsent() {
+        if (userUuid == null) {
+            userUuid = UUID.randomUUID();
+        }
+    }
+
+    public void addIdentity(Identity identity) {
+        identities.add(identity);
+        identity.assignUser(this);
+    }
+}

--- a/src/main/java/com/pj/login/domain/auth/entity/User.java
+++ b/src/main/java/com/pj/login/domain/auth/entity/User.java
@@ -2,15 +2,7 @@ package com.pj.login.domain.auth.entity;
 
 import com.pj.login.common.converter.YesNoBooleanConverter;
 import com.pj.login.common.entity.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -67,19 +59,13 @@ public class User extends BaseTimeEntity {
             boolean phoneVerified,
             LocalDateTime lastLoginAt
     ) {
-        this.userUuid = userUuid;
+        this.userUuid = userUuid != null ? userUuid : UUID.randomUUID();
         this.accountStatus = accountStatus;
         this.email = email;
         this.emailVerified = emailVerified;
         this.phoneNumber = phoneNumber;
         this.phoneVerified = phoneVerified;
         this.lastLoginAt = lastLoginAt;
-    }
-
-    void assignUserUuidIfAbsent() {
-        if (userUuid == null) {
-            userUuid = UUID.randomUUID();
-        }
     }
 
     public void addIdentity(Identity identity) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  application:
+    name: login
+  datasource:
+    url: jdbc:postgresql://localhost:5432/login?currentSchema=public&serverTimezone=Asia/Seoul
+    username: root
+    password: root
+    driver-class-name: org.postgresql.Driver
+  data:
+    redis:
+      host: localhost
+      port: 6380
+      timeout: 2s
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
+  sql:
+    init:
+      mode: never
+
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
## 작업 목적
- 로그인 서비스 개발을 위한 로컬 실행 환경을 구성하고, 로그인 도메인의 기본 엔티티 구조를 설계합니다.
- PostgreSQL, Redis 기반의 개발 환경을 마련하고 JPA 엔티티 매핑의 기본 뼈대를 추가합니다.

## 주요 변경 사항
- Spring Boot 프로젝트에 `JPA, Redis, Security, OAuth2 Client, Validation, PostgreSQL` 관련 의존성 추가
- 로컬 개발용 application.yml에 PostgreSQL 및 Redis 연결 설정 추가
- `docker-compose.yml`에 PostgreSQL, Redis 컨테이너 구성 추가
- 공통 엔티티 베이스 클래스로 `BaseTimeEntity`, `CreatedAtEntity`를 추가
- Y/N 컬럼 처리를 위한 `YesNoBooleanConverter` 추가
- 로그인 도메인 엔티티 `User`, `Identity,` `Password`, `LoginHistory` 추가
   - 기본 필드와 관계 설계

## 확인 필요 사항
1. LoginHistory를 User 엔티티 연관관계로 유지할지, userId 값만 저장하는 스냅샷 형태로 유지할지 정책 확정 필요
2. JPA 매핑 기준으로 테이블명, 컬럼 타입, UUID 저장 방식이 실제 운영 방향과 맞는지 확인 필요
3. 현재는 연관 엔티티 탐색 편의를 위해서 @OneToMany 양방향 매핑 적용중, 
실제 조회 패턴과 컬렉션 관리 비용을 고려해 유지 여부 결정 필요

## 테스트 여부

- [x] 완료 여부