### PR TITLE
[feat] 리프레시 토큰 발급 및 재발급 API 구현

### DIFF
--- a/docs/04-api/api-README.md
+++ b/docs/04-api/api-README.md
@@ -14,7 +14,7 @@
 | 로그인 | POST | /api/v1/auth/login | 일반 로그인 및 JWT 발급 |
 | 소셜 로그인 | POST | /api/v1/auth/social/login | 소셜 로그인 처리 및 JWT 발급 |
 | 로그아웃 | POST | /api/v1/auth/logout | Refresh Token 무효화 |
-| 토큰 재발급 | POST | /api/v1/auth/token/refresh | Access Token 재발급 |
+| 토큰 재발급 | POST | /api/v1/auth/token/refresh | Access/Refresh Token 재발급 |
 | 토큰 검증 | GET | /api/v1/auth/token/verify | Access Token 유효성 확인 |
 | 이메일 인증 번호 발송 | POST   | `/api/v1/auth/email/send` | 이메일 인증 번호 발송 (개발고려) |
 | 이메일 인증 확인  | POST   | `/api/v1/auth/email/verify` | 이메일 인증 확인 (개발 고려)   |

--- a/docs/04-api/auth-api.md
+++ b/docs/04-api/auth-api.md
@@ -41,7 +41,7 @@ Auth API는 인증 자체를 담당하며, 사용자 상세 정보 관리나 계
 | 로그인 | POST   | `/api/v1/auth/login` | 일반 로그인 및 JWT 발급     |
 | 소셜 로그인 | POST   | `/api/v1/auth/social/login` | 소셜 로그인 처리 및 JWT 발급  |
 | 로그아웃 | POST   | `/api/v1/auth/logout` | Refresh Token 무효화   |
-| 토큰 재발급 | POST   | `/api/v1/auth/token/refresh` | Access Token 재발급    |
+| 토큰 재발급 | POST   | `/api/v1/auth/token/refresh` | Access/Refresh Token 재발급 |
 | 토큰 검증 | GET    | `/api/v1/auth/token/verify` | Access Token 유효성 확인 |
 | 이메일 인증 번호 발송 | POST   | `/api/v1/auth/email/send` | 이메일 인증 번호 발송 (개발고려) |
 | 이메일 인증 확인  | POST   | `/api/v1/auth/email/verify` | 이메일 인증 확인 (개발 고려)   |
@@ -488,8 +488,7 @@ Auth API는 인증 자체를 담당하며, 사용자 상세 정보 관리나 계
 ### 5.5 토큰 재발급
 
 ### 개요
-Refresh Token을 이용하여 새로운 Access Token을 발급한다.  
-필요 시 Refresh Token도 함께 재발급할 수 있다.
+Refresh Token을 이용하여 새로운 Access Token과 Refresh Token을 발급한다.
 
 ---
 
@@ -548,7 +547,7 @@ Refresh Token을 이용하여 새로운 Access Token을 발급한다.
   "data": {
     "accessToken": "new-access-token",
     "refreshToken": "new-refresh-token",
-    "expiresIn": 3600
+    "expiresIn": 1800
   }
 }
 ```

--- a/src/main/java/com/pj/login/common/config/JwtProperties.java
+++ b/src/main/java/com/pj/login/common/config/JwtProperties.java
@@ -4,10 +4,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.nio.charset.StandardCharsets;
 
+/**
+ * JWT 관련 설정을 담는 클래스
+ * application.yml에서 app.jwt로 시작하는 설정을 이 클래스의 필드에 매핑
+ */
 @ConfigurationProperties(prefix = "app.jwt")
 public record JwtProperties(
         String issuer,
         long accessTokenExpirySeconds,
+        long refreshTokenExpirySeconds,
         String secret
 ) {
     public JwtProperties {
@@ -16,6 +21,9 @@ public record JwtProperties(
         }
         if (accessTokenExpirySeconds <= 0) {
             throw new IllegalArgumentException("액세스 토큰 만료 시간은 0보다 커야 합니다.");
+        }
+        if (refreshTokenExpirySeconds <= 0) {
+            throw new IllegalArgumentException("리프레시 토큰 만료 시간은 0보다 커야 합니다.");
         }
         if (secret.getBytes(StandardCharsets.UTF_8).length < 32) {
             throw new IllegalArgumentException("JWT secret은 최소 32바이트 이상이어야 합니다.");

--- a/src/main/java/com/pj/login/common/config/SecurityConfig.java
+++ b/src/main/java/com/pj/login/common/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/signup").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/token/refresh").permitAll()
                         .requestMatchers(
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",

--- a/src/main/java/com/pj/login/common/security/refresh/RedisRefreshTokenStore.java
+++ b/src/main/java/com/pj/login/common/security/refresh/RedisRefreshTokenStore.java
@@ -12,6 +12,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.HexFormat;
+import java.util.Optional;
 import java.util.UUID;
 
 @Component
@@ -28,6 +29,26 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     public void save(String refreshToken, UUID userUuid, Duration ttl) {
         stringRedisTemplate.opsForValue()
                 .set(refreshTokenKey(refreshToken), userUuid.toString(), ttl);
+    }
+
+    @Override
+    public Optional<UUID> consumeUserUuid(String refreshToken) {
+        String userUuid = stringRedisTemplate.opsForValue()
+                // getAndDelete로 기존 refresh token을 소비해서 재사용 방지
+                .getAndDelete(refreshTokenKey(refreshToken));
+        if (userUuid == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(UUID.fromString(userUuid));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void delete(String refreshToken) {
+        stringRedisTemplate.delete(refreshTokenKey(refreshToken));
     }
 
     private String refreshTokenKey(String refreshToken) {

--- a/src/main/java/com/pj/login/common/security/refresh/RedisRefreshTokenStore.java
+++ b/src/main/java/com/pj/login/common/security/refresh/RedisRefreshTokenStore.java
@@ -1,0 +1,47 @@
+package com.pj.login.common.security.refresh;
+
+import com.pj.login.common.config.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRefreshTokenStore implements RefreshTokenStore {
+
+    private static final String KEY_PREFIX = "auth:rt:v1:";
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final JwtProperties jwtProperties;
+
+    @Override
+    public void save(String refreshToken, UUID userUuid, Duration ttl) {
+        stringRedisTemplate.opsForValue()
+                .set(refreshTokenKey(refreshToken), userUuid.toString(), ttl);
+    }
+
+    private String refreshTokenKey(String refreshToken) {
+        // Redis key 노출 시 refresh token 원문이 새지 않도록 HMAC digest만 저장
+        return KEY_PREFIX + hmacSha256(refreshToken);
+    }
+
+    private String hmacSha256(String refreshToken) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(jwtProperties.secretBytes(), HMAC_ALGORITHM));
+            return HexFormat.of().formatHex(mac.doFinal(refreshToken.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException | InvalidKeyException ex) {
+            throw new IllegalStateException("Refresh token 해시 생성 중 오류가 발생했습니다.", ex);
+        }
+    }
+}

--- a/src/main/java/com/pj/login/common/security/refresh/RefreshTokenService.java
+++ b/src/main/java/com/pj/login/common/security/refresh/RefreshTokenService.java
@@ -1,0 +1,50 @@
+package com.pj.login.common.security.refresh;
+
+import com.pj.login.common.config.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final int REFRESH_TOKEN_BYTE_LENGTH = 32;
+
+    private final JwtProperties jwtProperties;
+    private final RefreshTokenStore refreshTokenStore;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public RefreshToken issueRefreshToken(UUID userUuid, LocalDateTime issuedAt) {
+        String token = generateToken();
+        Duration ttl = Duration.ofSeconds(jwtProperties.refreshTokenExpirySeconds());
+
+        refreshTokenStore.save(token, userUuid, ttl);
+
+        return new RefreshToken(token, issuedAt.plus(ttl));
+    }
+
+    /**
+     * 보안을 위해 URL-safe Base64 인코딩된 랜덤 바이트 배열을 사용하여 토큰을 생성합니다.
+     * padding 문자를 제거하여 토큰 길이를 줄입니다.
+     */
+
+    private String generateToken() {
+        byte[] randomBytes = new byte[REFRESH_TOKEN_BYTE_LENGTH];
+        secureRandom.nextBytes(randomBytes);
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(randomBytes);
+    }
+
+    public record RefreshToken(
+            String token,
+            LocalDateTime expiresAt
+    ) {
+    }
+}

--- a/src/main/java/com/pj/login/common/security/refresh/RefreshTokenService.java
+++ b/src/main/java/com/pj/login/common/security/refresh/RefreshTokenService.java
@@ -8,6 +8,7 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -27,6 +28,14 @@ public class RefreshTokenService {
         refreshTokenStore.save(token, userUuid, ttl);
 
         return new RefreshToken(token, issuedAt.plus(ttl));
+    }
+
+    public Optional<UUID> consumeUserUuid(String refreshToken) {
+        return refreshTokenStore.consumeUserUuid(refreshToken);
+    }
+
+    public void revokeRefreshToken(String refreshToken) {
+        refreshTokenStore.delete(refreshToken);
     }
 
     /**

--- a/src/main/java/com/pj/login/common/security/refresh/RefreshTokenStore.java
+++ b/src/main/java/com/pj/login/common/security/refresh/RefreshTokenStore.java
@@ -1,9 +1,14 @@
 package com.pj.login.common.security.refresh;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface RefreshTokenStore {
 
     void save(String refreshToken, UUID userUuid, Duration ttl);
+
+    Optional<UUID> consumeUserUuid(String refreshToken);
+
+    void delete(String refreshToken);
 }

--- a/src/main/java/com/pj/login/common/security/refresh/RefreshTokenStore.java
+++ b/src/main/java/com/pj/login/common/security/refresh/RefreshTokenStore.java
@@ -1,0 +1,9 @@
+package com.pj.login.common.security.refresh;
+
+import java.time.Duration;
+import java.util.UUID;
+
+public interface RefreshTokenStore {
+
+    void save(String refreshToken, UUID userUuid, Duration ttl);
+}

--- a/src/main/java/com/pj/login/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pj/login/domain/auth/controller/AuthController.java
@@ -5,31 +5,32 @@ import com.pj.login.domain.auth.dto.LoginRequest;
 import com.pj.login.domain.auth.dto.LoginResponse;
 import com.pj.login.domain.auth.dto.SignupRequest;
 import com.pj.login.domain.auth.dto.SignupResponse;
+import com.pj.login.domain.auth.dto.TokenRefreshRequest;
+import com.pj.login.domain.auth.dto.TokenRefreshResponse;
 import com.pj.login.domain.auth.service.AuthLoginService;
 import com.pj.login.domain.auth.service.AuthSignupService;
+import com.pj.login.domain.auth.service.AuthTokenRefreshService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 @Tag(name = "Auth", description = "Auth API")
 public class AuthController {
 
     private final AuthLoginService authLoginService;
     private final AuthSignupService authSignupService;
-
-    public AuthController(AuthLoginService authLoginService, AuthSignupService authSignupService) {
-        this.authLoginService = authLoginService;
-        this.authSignupService = authSignupService;
-    }
+    private final AuthTokenRefreshService authTokenRefreshService;
 
     @Operation(summary = "로그인", description = "로컬 계정 로그인 처리를 수행합니다.")
     @ApiResponses(value = {
@@ -58,6 +59,17 @@ public class AuthController {
     @PostMapping("/signup")
     public ApiResult<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
         return ApiResult.success(authSignupService.signup(request));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 이용해 Access Token과 Refresh Token을 재발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token"),
+            @ApiResponse(responseCode = "403", description = "로그인 불가 상태의 계정")
+    })
+    @PostMapping("/token/refresh")
+    public ApiResult<TokenRefreshResponse> refreshToken(@Valid @RequestBody TokenRefreshRequest request) {
+        return ApiResult.success(authTokenRefreshService.refresh(request));
     }
 
     /**

--- a/src/main/java/com/pj/login/domain/auth/controller/AuthExceptionHandler.java
+++ b/src/main/java/com/pj/login/domain/auth/controller/AuthExceptionHandler.java
@@ -4,6 +4,7 @@ import com.pj.login.common.response.ApiResult;
 import com.pj.login.domain.auth.exception.AuthLoginException;
 import com.pj.login.domain.auth.exception.DuplicateEmailException;
 import com.pj.login.domain.auth.exception.DuplicateLoginIdException;
+import com.pj.login.domain.auth.exception.InvalidRefreshTokenException;
 import com.pj.login.domain.auth.exception.LoginNotAllowedException;
 import com.pj.login.domain.auth.exception.PasswordLockedException;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -44,6 +45,12 @@ public class AuthExceptionHandler {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ApiResult<Void> handleAuthLoginFailure(AuthLoginException ex) {
         return ApiResult.error("INVALID_LOGIN_CREDENTIALS", "로그인 ID 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ApiResult<Void> handleInvalidRefreshToken(InvalidRefreshTokenException ex) {
+        return ApiResult.error("INVALID_REFRESH_TOKEN", ex.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/pj/login/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/pj/login/domain/auth/dto/LoginResponse.java
@@ -1,6 +1,5 @@
 package com.pj.login.domain.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.pj.login.domain.auth.constant.AccountStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -14,8 +13,7 @@ public record LoginResponse(
         @Schema(description = "액세스 토큰")
         String accessToken,
 
-        @JsonInclude(JsonInclude.Include.ALWAYS)
-        @Schema(description = "Refresh Token (현재 미발급으로 null 반환)", nullable = true)
+        @Schema(description = "Refresh Token")
         String refreshToken,
 
         @Schema(description = "계정 상태", example = "ACTIVE")

--- a/src/main/java/com/pj/login/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/pj/login/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,14 @@
+package com.pj.login.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "토큰 재발급 요청")
+public record TokenRefreshRequest(
+        @Schema(description = "Refresh Token", example = "refresh-token-value", maxLength = 500)
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        @Size(max = 500, message = "Refresh Token은 500자 이하여야 합니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/pj/login/domain/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/pj/login/domain/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,16 @@
+package com.pj.login.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "토큰 재발급 응답")
+public record TokenRefreshResponse(
+        @Schema(description = "새 액세스 토큰")
+        String accessToken,
+
+        @Schema(description = "새 Refresh Token")
+        String refreshToken,
+
+        @Schema(description = "액세스 토큰 만료 시간(초)", example = "1800")
+        long expiresIn
+) {
+}

--- a/src/main/java/com/pj/login/domain/auth/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/pj/login/domain/auth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,8 @@
+package com.pj.login.domain.auth.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+
+    public InvalidRefreshTokenException() {
+        super("Refresh Token이 유효하지 않습니다.");
+    }
+}

--- a/src/main/java/com/pj/login/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/pj/login/domain/auth/repository/UserRepository.java
@@ -4,8 +4,10 @@ import com.pj.login.domain.auth.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    Optional<User> findByUserUuid(UUID userUuid);
 }

--- a/src/main/java/com/pj/login/domain/auth/service/AuthLoginService.java
+++ b/src/main/java/com/pj/login/domain/auth/service/AuthLoginService.java
@@ -1,6 +1,7 @@
 package com.pj.login.domain.auth.service;
 
 import com.pj.login.common.security.JwtTokenService;
+import com.pj.login.common.security.refresh.RefreshTokenService;
 import com.pj.login.common.time.TimeProvider;
 import com.pj.login.domain.auth.constant.AccountStatus;
 import com.pj.login.domain.auth.constant.LoginFailureReason;
@@ -37,6 +38,7 @@ public class AuthLoginService {
     private final IdentityRepository identityRepository;
     private final LoginHistoryRepository loginHistoryRepository;
     private final JwtTokenService jwtTokenService;
+    private final RefreshTokenService refreshTokenService;
     private final PasswordHashingService passwordHashingService;
     private final TimeProvider timeProvider;
 
@@ -128,11 +130,13 @@ public class AuthLoginService {
 
         JwtTokenService.JwtToken accessToken =
                 jwtTokenService.issueAccessToken(user.getUserUuid(), loginContext.attemptedAt());
+        RefreshTokenService.RefreshToken refreshToken =
+                refreshTokenService.issueRefreshToken(user.getUserUuid(), loginContext.attemptedAt());
 
         return new LoginResponse(
                 user.getUserUuid(),
                 accessToken.token(),
-                null,
+                refreshToken.token(),
                 user.getAccountStatus()
         );
     }

--- a/src/main/java/com/pj/login/domain/auth/service/AuthTokenRefreshService.java
+++ b/src/main/java/com/pj/login/domain/auth/service/AuthTokenRefreshService.java
@@ -1,0 +1,56 @@
+package com.pj.login.domain.auth.service;
+
+import com.pj.login.common.config.JwtProperties;
+import com.pj.login.common.security.JwtTokenService;
+import com.pj.login.common.security.refresh.RefreshTokenService;
+import com.pj.login.common.time.TimeProvider;
+import com.pj.login.domain.auth.constant.AccountStatus;
+import com.pj.login.domain.auth.dto.TokenRefreshRequest;
+import com.pj.login.domain.auth.dto.TokenRefreshResponse;
+import com.pj.login.domain.auth.entity.User;
+import com.pj.login.domain.auth.exception.InvalidRefreshTokenException;
+import com.pj.login.domain.auth.exception.LoginNotAllowedException;
+import com.pj.login.domain.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthTokenRefreshService {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenService jwtTokenService;
+    private final UserRepository userRepository;
+    private final TimeProvider timeProvider;
+    private final JwtProperties jwtProperties;
+
+    public TokenRefreshResponse refresh(TokenRefreshRequest request) {
+        UUID userUuid = refreshTokenService.consumeUserUuid(request.refreshToken())
+                .orElseThrow(InvalidRefreshTokenException::new);
+        User user = userRepository.findByUserUuid(userUuid)
+                .orElseThrow(InvalidRefreshTokenException::new);
+        validateAccountStatus(user);
+
+        LocalDateTime issuedAt = timeProvider.now();
+        JwtTokenService.JwtToken accessToken = jwtTokenService.issueAccessToken(user.getUserUuid(), issuedAt);
+        RefreshTokenService.RefreshToken refreshToken =
+                refreshTokenService.issueRefreshToken(user.getUserUuid(), issuedAt);
+
+        return new TokenRefreshResponse(
+                accessToken.token(),
+                refreshToken.token(),
+                jwtProperties.accessTokenExpirySeconds()
+        );
+    }
+
+    private static void validateAccountStatus(User user) {
+        if (user.getAccountStatus() != AccountStatus.ACTIVE) {
+            throw new LoginNotAllowedException();
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,4 +5,5 @@ spring:
 
 app:
   jwt:
+    refresh-token-expiry-seconds: ${JWT_REFRESH_TOKEN_EXPIRY_SECONDS:1209600}
     secret: ${JWT_SECRET:dev-only-jwt-secret-key-change-me-1234567890-abcdef}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,9 @@ spring:
     driver-class-name: org.postgresql.Driver
   data:
     redis:
-      host: localhost
-      port: 6380
-      timeout: 2s
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6380}
+      timeout: ${REDIS_TIMEOUT:2s}
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -33,4 +33,5 @@ app:
   jwt:
     issuer: taesin
     access-token-expiry-seconds: 1800
+    refresh-token-expiry-seconds: ${JWT_REFRESH_TOKEN_EXPIRY_SECONDS:1209600}
     secret: ${JWT_SECRET}

--- a/src/test/java/com/pj/login/common/security/RedisRefreshTokenStoreTest.java
+++ b/src/test/java/com/pj/login/common/security/RedisRefreshTokenStoreTest.java
@@ -55,6 +55,32 @@ class RedisRefreshTokenStoreTest {
         assertThat(redisKey).isEqualTo("auth:rt:v1:" + hmacSha256(RAW_REFRESH_TOKEN, TEST_SECRET));
     }
 
+    @Test
+    @DisplayName("HMAC 해시 키로 저장된 사용자 UUID를 조회하고 삭제한다")
+    void consume_user_uuid_by_hmac_digest_key() throws Exception {
+        JwtProperties jwtProperties = new JwtProperties("taesin", 1800, 1209600, TEST_SECRET);
+        RedisRefreshTokenStore refreshTokenStore = new RedisRefreshTokenStore(stringRedisTemplate, jwtProperties);
+        UUID userUuid = UUID.randomUUID();
+        String redisKey = "auth:rt:v1:" + hmacSha256(RAW_REFRESH_TOKEN, TEST_SECRET);
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete(redisKey)).willReturn(userUuid.toString());
+
+        assertThat(refreshTokenStore.consumeUserUuid(RAW_REFRESH_TOKEN)).contains(userUuid);
+    }
+
+    @Test
+    @DisplayName("HMAC 해시 키로 리프레시 토큰을 삭제한다")
+    void delete_by_hmac_digest_key() throws Exception {
+        JwtProperties jwtProperties = new JwtProperties("taesin", 1800, 1209600, TEST_SECRET);
+        RedisRefreshTokenStore refreshTokenStore = new RedisRefreshTokenStore(stringRedisTemplate, jwtProperties);
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+
+        refreshTokenStore.delete(RAW_REFRESH_TOKEN);
+
+        then(stringRedisTemplate).should().delete(keyCaptor.capture());
+        assertThat(keyCaptor.getValue()).isEqualTo("auth:rt:v1:" + hmacSha256(RAW_REFRESH_TOKEN, TEST_SECRET));
+    }
+
     private String hmacSha256(String value, String secret) throws Exception {
         Mac mac = Mac.getInstance("HmacSHA256");
         mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));

--- a/src/test/java/com/pj/login/common/security/RedisRefreshTokenStoreTest.java
+++ b/src/test/java/com/pj/login/common/security/RedisRefreshTokenStoreTest.java
@@ -1,0 +1,63 @@
+package com.pj.login.common.security;
+
+import com.pj.login.common.config.JwtProperties;
+import com.pj.login.common.security.refresh.RedisRefreshTokenStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class RedisRefreshTokenStoreTest {
+
+    private static final String TEST_SECRET = "test-only-jwt-secret-key-change-me-1234567890-abcdef";
+    private static final String RAW_REFRESH_TOKEN = "raw-refresh-token-value";
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Test
+    @DisplayName("Redis key에는 리프레시 토큰 원문이 아니라 HMAC 해시를 사용한다")
+    void save_uses_hmac_digest_key() throws Exception {
+        JwtProperties jwtProperties = new JwtProperties("taesin", 1800, 1209600, TEST_SECRET);
+        RedisRefreshTokenStore refreshTokenStore = new RedisRefreshTokenStore(stringRedisTemplate, jwtProperties);
+        UUID userUuid = UUID.randomUUID();
+        Duration ttl = Duration.ofDays(14);
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+
+        refreshTokenStore.save(RAW_REFRESH_TOKEN, userUuid, ttl);
+
+        then(valueOperations).should().set(keyCaptor.capture(), eq(userUuid.toString()), eq(ttl));
+        String redisKey = keyCaptor.getValue();
+
+        assertThat(redisKey).startsWith("auth:rt:v1:");
+        assertThat(redisKey).doesNotContain(RAW_REFRESH_TOKEN);
+        assertThat(redisKey).isEqualTo("auth:rt:v1:" + hmacSha256(RAW_REFRESH_TOKEN, TEST_SECRET));
+    }
+
+    private String hmacSha256(String value, String secret) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        return HexFormat.of().formatHex(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/test/java/com/pj/login/common/security/RefreshTokenServiceTest.java
+++ b/src/test/java/com/pj/login/common/security/RefreshTokenServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,17 +36,62 @@ class RefreshTokenServiceTest {
         assertThat(refreshTokenStore.ttl).isEqualTo(Duration.ofSeconds(1209600));
     }
 
+    @Test
+    @DisplayName("리프레시 토큰으로 사용자 UUID를 조회하고 소비한다")
+    void consume_user_uuid_by_refresh_token() {
+        CapturingRefreshTokenStore refreshTokenStore = new CapturingRefreshTokenStore();
+        RefreshTokenService refreshTokenService = new RefreshTokenService(
+                new JwtProperties("taesin", 1800, 1209600, TEST_SECRET),
+                refreshTokenStore
+        );
+        UUID userUuid = UUID.randomUUID();
+        refreshTokenStore.save("refresh-token", userUuid, Duration.ofDays(14));
+
+        Optional<UUID> foundUserUuid = refreshTokenService.consumeUserUuid("refresh-token");
+
+        assertThat(foundUserUuid).contains(userUuid);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰을 폐기한다")
+    void revoke_refresh_token() {
+        CapturingRefreshTokenStore refreshTokenStore = new CapturingRefreshTokenStore();
+        RefreshTokenService refreshTokenService = new RefreshTokenService(
+                new JwtProperties("taesin", 1800, 1209600, TEST_SECRET),
+                refreshTokenStore
+        );
+        refreshTokenStore.save("refresh-token", UUID.randomUUID(), Duration.ofDays(14));
+
+        refreshTokenService.revokeRefreshToken("refresh-token");
+
+        assertThat(refreshTokenStore.deletedRefreshToken).isEqualTo("refresh-token");
+    }
+
     private static class CapturingRefreshTokenStore implements RefreshTokenStore {
 
         private String refreshToken;
         private UUID userUuid;
         private Duration ttl;
+        private String deletedRefreshToken;
 
         @Override
         public void save(String refreshToken, UUID userUuid, Duration ttl) {
             this.refreshToken = refreshToken;
             this.userUuid = userUuid;
             this.ttl = ttl;
+        }
+
+        @Override
+        public Optional<UUID> consumeUserUuid(String refreshToken) {
+            if (refreshToken.equals(this.refreshToken)) {
+                return Optional.of(userUuid);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public void delete(String refreshToken) {
+            this.deletedRefreshToken = refreshToken;
         }
     }
 }

--- a/src/test/java/com/pj/login/common/security/RefreshTokenServiceTest.java
+++ b/src/test/java/com/pj/login/common/security/RefreshTokenServiceTest.java
@@ -1,0 +1,51 @@
+package com.pj.login.common.security;
+
+import com.pj.login.common.config.JwtProperties;
+import com.pj.login.common.security.refresh.RefreshTokenService;
+import com.pj.login.common.security.refresh.RefreshTokenStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RefreshTokenServiceTest {
+
+    private static final String TEST_SECRET = "test-only-jwt-secret-key-change-me-1234567890-abcdef";
+
+    @Test
+    @DisplayName("리프레시 토큰을 생성하고 TTL과 함께 저장한다")
+    void issue_refresh_token_saves_token_with_ttl() {
+        JwtProperties jwtProperties = new JwtProperties("taesin", 1800, 1209600, TEST_SECRET);
+        CapturingRefreshTokenStore refreshTokenStore = new CapturingRefreshTokenStore();
+        RefreshTokenService refreshTokenService = new RefreshTokenService(jwtProperties, refreshTokenStore);
+        UUID userUuid = UUID.randomUUID();
+        LocalDateTime issuedAt = LocalDateTime.of(2026, 5, 7, 12, 0);
+
+        RefreshTokenService.RefreshToken refreshToken =
+                refreshTokenService.issueRefreshToken(userUuid, issuedAt);
+
+        assertThat(refreshToken.token()).isNotBlank();
+        assertThat(refreshToken.token()).isEqualTo(refreshTokenStore.refreshToken);
+        assertThat(refreshToken.expiresAt()).isEqualTo(issuedAt.plusSeconds(1209600));
+        assertThat(refreshTokenStore.userUuid).isEqualTo(userUuid);
+        assertThat(refreshTokenStore.ttl).isEqualTo(Duration.ofSeconds(1209600));
+    }
+
+    private static class CapturingRefreshTokenStore implements RefreshTokenStore {
+
+        private String refreshToken;
+        private UUID userUuid;
+        private Duration ttl;
+
+        @Override
+        public void save(String refreshToken, UUID userUuid, Duration ttl) {
+            this.refreshToken = refreshToken;
+            this.userUuid = userUuid;
+            this.ttl = ttl;
+        }
+    }
+}

--- a/src/test/java/com/pj/login/domain/auth/controller/AuthControllerLoginTest.java
+++ b/src/test/java/com/pj/login/domain/auth/controller/AuthControllerLoginTest.java
@@ -1,6 +1,7 @@
 package com.pj.login.domain.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pj.login.common.security.refresh.RefreshTokenStore;
 import com.pj.login.common.time.TimeProvider;
 import com.pj.login.domain.auth.constant.AccountStatus;
 import com.pj.login.domain.auth.constant.PasswordAlgo;
@@ -16,6 +17,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,7 +27,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -55,8 +58,8 @@ class AuthControllerLoginTest {
     }
 
     @Test
-    @DisplayName("로그인 성공 시 액세스 토큰을 반환한다")
-    void login_success_returns_access_token() throws Exception {
+    @DisplayName("로그인 성공 시 액세스 토큰과 리프레시 토큰을 반환한다")
+    void login_success_returns_access_and_refresh_token() throws Exception {
         seedUser("controller-login@example.com");
 
         LoginRequest request = new LoginRequest("controller-login@example.com", "Password123!");
@@ -68,7 +71,7 @@ class AuthControllerLoginTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.userUuid").isNotEmpty())
                 .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
+                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
                 .andExpect(jsonPath("$.data.accountStatus").value("ACTIVE"))
                 .andExpect(jsonPath("$.data.accessTokenExpiresAt").doesNotExist())
                 .andExpect(jsonPath("$.data.loginAt").doesNotExist());
@@ -151,5 +154,16 @@ class AuthControllerLoginTest {
         identity.addPassword(password);
         user.addIdentity(identity);
         userRepository.save(user);
+    }
+
+    @TestConfiguration
+    static class RefreshTokenStoreTestConfig {
+
+        @Bean
+        @Primary
+        RefreshTokenStore refreshTokenStore() {
+            return (refreshToken, userUuid, ttl) -> {
+            };
+        }
     }
 }

--- a/src/test/java/com/pj/login/domain/auth/controller/AuthControllerLoginTest.java
+++ b/src/test/java/com/pj/login/domain/auth/controller/AuthControllerLoginTest.java
@@ -1,5 +1,6 @@
 package com.pj.login.domain.auth.controller;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pj.login.common.security.refresh.RefreshTokenStore;
 import com.pj.login.common.time.TimeProvider;
@@ -23,10 +24,18 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -123,6 +132,64 @@ class AuthControllerLoginTest {
                 .andExpect(jsonPath("$.error.message").value("로그인 ID는 필수입니다."));
     }
 
+    @Test
+    @DisplayName("리프레시 토큰으로 액세스 토큰과 리프레시 토큰을 재발급한다")
+    void refresh_token_success_rotates_refresh_token() throws Exception {
+        seedUser("refresh-controller@example.com");
+        LoginRequest loginRequest = new LoginRequest("refresh-controller@example.com", "Password123!");
+
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+        String oldRefreshToken = readData(loginResult, "refreshToken").asText();
+
+        MvcResult refreshResult = mockMvc.perform(post("/api/v1/auth/token/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("refreshToken", oldRefreshToken))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.expiresIn").value(1800))
+                .andReturn();
+
+        String newRefreshToken = readData(refreshResult, "refreshToken").asText();
+        assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
+
+        mockMvc.perform(post("/api/v1/auth/token/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("refreshToken", oldRefreshToken))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REFRESH_TOKEN"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰이면 401을 반환한다")
+    void refresh_token_invalid_returns_unauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/token/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("refreshToken", "invalid-refresh-token"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REFRESH_TOKEN"))
+                .andExpect(jsonPath("$.error.message").value("Refresh Token이 유효하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 누락 시 검증 에러를 반환한다")
+    void refresh_token_missing_returns_validation_error() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/token/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("refreshToken", ""))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.error.message").value("Refresh Token은 필수입니다."));
+    }
+
     private void seedUser(String loginId) {
         seedUser(loginId, AccountStatus.ACTIVE);
     }
@@ -156,14 +223,39 @@ class AuthControllerLoginTest {
         userRepository.save(user);
     }
 
+    private JsonNode readData(MvcResult result, String fieldName) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .path("data")
+                .path(fieldName);
+    }
+
     @TestConfiguration
     static class RefreshTokenStoreTestConfig {
 
         @Bean
         @Primary
         RefreshTokenStore refreshTokenStore() {
-            return (refreshToken, userUuid, ttl) -> {
-            };
+            return new InMemoryRefreshTokenStore();
+        }
+
+        static class InMemoryRefreshTokenStore implements RefreshTokenStore {
+
+            private final Map<String, UUID> tokens = new ConcurrentHashMap<>();
+
+            @Override
+            public void save(String refreshToken, UUID userUuid, Duration ttl) {
+                tokens.put(refreshToken, userUuid);
+            }
+
+            @Override
+            public Optional<UUID> consumeUserUuid(String refreshToken) {
+                return Optional.ofNullable(tokens.remove(refreshToken));
+            }
+
+            @Override
+            public void delete(String refreshToken) {
+                tokens.remove(refreshToken);
+            }
         }
     }
 }

--- a/src/test/java/com/pj/login/domain/auth/service/AuthLoginServiceTest.java
+++ b/src/test/java/com/pj/login/domain/auth/service/AuthLoginServiceTest.java
@@ -1,6 +1,7 @@
 package com.pj.login.domain.auth.service;
 
 import com.pj.login.common.security.JwtTokenService;
+import com.pj.login.common.security.refresh.RefreshTokenService;
 import com.pj.login.common.time.KoreaTime;
 import com.pj.login.common.time.TimeProvider;
 import com.pj.login.domain.auth.constant.AccountStatus;
@@ -61,6 +62,9 @@ class AuthLoginServiceTest {
     private JwtTokenService jwtTokenService;
 
     @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
     private PasswordHashingService passwordHashingService;
 
     @Spy
@@ -104,7 +108,7 @@ class AuthLoginServiceTest {
             assertSoftly(softly -> {
                 softly.assertThat(response.userUuid()).isEqualTo(fixture.user().getUserUuid());
                 softly.assertThat(response.accessToken()).isEqualTo("access-token");
-                softly.assertThat(response.refreshToken()).isNull();
+                softly.assertThat(response.refreshToken()).isEqualTo("refresh-token");
                 softly.assertThat(response.accountStatus()).isEqualTo(AccountStatus.ACTIVE);
                 softly.assertThat(fixture.user().getLastLoginAt()).isEqualTo(issuedAt);
                 softly.assertThat(fixture.password().getFailCount()).isZero();
@@ -152,6 +156,7 @@ class AuthLoginServiceTest {
             });
 
             then(jwtTokenService).shouldHaveNoInteractions();
+            then(refreshTokenService).shouldHaveNoInteractions();
         }
 
         @Test
@@ -183,6 +188,7 @@ class AuthLoginServiceTest {
 
             then(passwordHashingService).shouldHaveNoInteractions();
             then(jwtTokenService).shouldHaveNoInteractions();
+            then(refreshTokenService).shouldHaveNoInteractions();
         }
 
         @Test
@@ -214,6 +220,7 @@ class AuthLoginServiceTest {
 
             then(passwordHashingService).shouldHaveNoInteractions();
             then(jwtTokenService).shouldHaveNoInteractions();
+            then(refreshTokenService).shouldHaveNoInteractions();
         }
 
         @Test
@@ -240,6 +247,7 @@ class AuthLoginServiceTest {
                 softly.assertThat(response.userUuid()).isEqualTo(fixture.user().getUserUuid());
                 softly.assertThat(response.accountStatus()).isEqualTo(AccountStatus.ACTIVE);
                 softly.assertThat(response.accessToken()).isEqualTo("access-token");
+                softly.assertThat(response.refreshToken()).isEqualTo("refresh-token");
                 softly.assertThat(loginHistory.getLoginId()).isEqualTo("tester01");
                 softly.assertThat(loginHistory.getAttemptResult()).isEqualTo(LoginAttemptResult.SUCCESS);
             });
@@ -256,6 +264,11 @@ class AuthLoginServiceTest {
                 .willAnswer(invocation -> {
                     LocalDateTime issuedAt = invocation.getArgument(1);
                     return new JwtTokenService.JwtToken("access-token", issuedAt.plusSeconds(3600));
+                });
+        given(refreshTokenService.issueRefreshToken(eq(user.getUserUuid()), any(LocalDateTime.class)))
+                .willAnswer(invocation -> {
+                    LocalDateTime issuedAt = invocation.getArgument(1);
+                    return new RefreshTokenService.RefreshToken("refresh-token", issuedAt.plusDays(14));
                 });
     }
 

--- a/src/test/java/com/pj/login/domain/auth/service/AuthTokenRefreshServiceTest.java
+++ b/src/test/java/com/pj/login/domain/auth/service/AuthTokenRefreshServiceTest.java
@@ -1,0 +1,134 @@
+package com.pj.login.domain.auth.service;
+
+import com.pj.login.common.config.JwtProperties;
+import com.pj.login.common.security.JwtTokenService;
+import com.pj.login.common.security.refresh.RefreshTokenService;
+import com.pj.login.common.time.KoreaTime;
+import com.pj.login.common.time.TimeProvider;
+import com.pj.login.domain.auth.constant.AccountStatus;
+import com.pj.login.domain.auth.dto.TokenRefreshRequest;
+import com.pj.login.domain.auth.dto.TokenRefreshResponse;
+import com.pj.login.domain.auth.entity.User;
+import com.pj.login.domain.auth.exception.InvalidRefreshTokenException;
+import com.pj.login.domain.auth.exception.LoginNotAllowedException;
+import com.pj.login.domain.auth.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthTokenRefreshServiceTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-11T00:00:00Z");
+    private static final String TEST_SECRET = "test-only-jwt-secret-key-change-me-1234567890-abcdef";
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private JwtTokenService jwtTokenService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Spy
+    private TimeProvider timeProvider = new TimeProvider(Clock.fixed(FIXED_NOW, KoreaTime.ZONE_ID));
+
+    @Spy
+    private JwtProperties jwtProperties = new JwtProperties("taesin", 1800, 1209600, TEST_SECRET);
+
+    @InjectMocks
+    private AuthTokenRefreshService authTokenRefreshService;
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰이면 기존 토큰을 폐기하고 새 토큰들을 발급한다")
+    void refresh_rotates_refresh_token_and_issues_tokens() {
+        User user = activeUser();
+        UUID userUuid = user.getUserUuid();
+        given(refreshTokenService.consumeUserUuid("old-refresh-token")).willReturn(Optional.of(userUuid));
+        given(userRepository.findByUserUuid(userUuid)).willReturn(Optional.of(user));
+        given(jwtTokenService.issueAccessToken(eq(userUuid), any(LocalDateTime.class)))
+                .willAnswer(invocation -> {
+                    LocalDateTime issuedAt = invocation.getArgument(1);
+                    return new JwtTokenService.JwtToken("new-access-token", issuedAt.plusSeconds(1800));
+                });
+        given(refreshTokenService.issueRefreshToken(eq(userUuid), any(LocalDateTime.class)))
+                .willAnswer(invocation -> {
+                    LocalDateTime issuedAt = invocation.getArgument(1);
+                    return new RefreshTokenService.RefreshToken("new-refresh-token", issuedAt.plusDays(14));
+                });
+
+        TokenRefreshResponse response =
+                authTokenRefreshService.refresh(new TokenRefreshRequest("old-refresh-token"));
+
+        InOrder inOrder = inOrder(refreshTokenService, jwtTokenService);
+        inOrder.verify(refreshTokenService).consumeUserUuid("old-refresh-token");
+        inOrder.verify(jwtTokenService).issueAccessToken(eq(userUuid), any(LocalDateTime.class));
+        inOrder.verify(refreshTokenService).issueRefreshToken(eq(userUuid), any(LocalDateTime.class));
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.accessToken()).isEqualTo("new-access-token");
+            softly.assertThat(response.refreshToken()).isEqualTo("new-refresh-token");
+            softly.assertThat(response.expiresIn()).isEqualTo(1800);
+        });
+    }
+
+    @Test
+    @DisplayName("저장소에 없는 리프레시 토큰이면 예외를 던진다")
+    void refresh_invalid_token() {
+        given(refreshTokenService.consumeUserUuid("invalid-refresh-token")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authTokenRefreshService.refresh(new TokenRefreshRequest("invalid-refresh-token")))
+                .isInstanceOf(InvalidRefreshTokenException.class);
+
+        then(userRepository).shouldHaveNoInteractions();
+        then(jwtTokenService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("ACTIVE가 아닌 사용자의 리프레시 토큰이면 로그인 불가 예외를 던진다")
+    void refresh_not_active_user() {
+        User user = User.builder()
+                .accountStatus(AccountStatus.DORMANT)
+                .email("dormant@example.com")
+                .emailVerified(false)
+                .phoneVerified(false)
+                .build();
+        UUID userUuid = user.getUserUuid();
+        given(refreshTokenService.consumeUserUuid("refresh-token")).willReturn(Optional.of(userUuid));
+        given(userRepository.findByUserUuid(userUuid)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> authTokenRefreshService.refresh(new TokenRefreshRequest("refresh-token")))
+                .isInstanceOf(LoginNotAllowedException.class);
+
+        then(jwtTokenService).shouldHaveNoInteractions();
+    }
+
+    private User activeUser() {
+        return User.builder()
+                .accountStatus(AccountStatus.ACTIVE)
+                .email("active@example.com")
+                .emailVerified(false)
+                .phoneVerified(false)
+                .build();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,4 +18,5 @@ app:
   jwt:
     issuer: taesin
     access-token-expiry-seconds: 1800
+    refresh-token-expiry-seconds: 1209600
     secret: test-only-jwt-secret-key-change-me-1234567890-abcdef


### PR DESCRIPTION
## Issues
- close #7

## 작업 목적
- 로그인 성공 시 Refresh Token을 함께 발급하도록 인증 흐름을 확장했습니다.
- Refresh Token 기반 Access/Refresh Token 재발급 API를 추가했습니다.
- Refresh Token 재사용을 막기 위해 재발급 시 기존 토큰을 소비 처리하도록 구현했습니다.

## 주요 변경 사항
- Redis 기반 Refresh Token 저장소와 발급/소비/삭제 로직 추가
- 로그인 응답에 Refresh Token 포함
- `POST /api/v1/auth/token/refresh` 엔드포인트 추가
- 유효하지 않은 Refresh Token 요청에 대한 `INVALID_REFRESH_TOKEN` 401 응답 처리
- 비활성 계정의 토큰 재발급 차단
- 토큰 재발급 API 문서 업데이트
- Refresh Token 저장소, 서비스, 로그인/재발급 컨트롤러 테스트 추가

## 확인 필요 사항
1. Refresh Token 재발급 시 기존 토큰이 재사용 불가능한 정책으로 동작하는지 확인 부탁드립니다.
2. Refresh Token 만료 시간 기본값을 14일(`1209600초`)로 두는 정책이 적절한지 확인 부탁드립니다.
3. Redis 환경 변수(`REDIS_HOST`, `REDIS_PORT`, `REDIS_TIMEOUT`) 기본값이 배포 환경과 맞는지 확인 부탁드립니다.

## 테스트 여부
- [x] 완료 여부

`./gradlew test`
